### PR TITLE
Remove yarn installation from frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:latest
 
-RUN npm install -g yarn
 WORKDIR /src/
 
 CMD ["bash", "start.sh"]


### PR DESCRIPTION
It seems that the `node:latest` image already includes yarn, which causes an error message when trying to build the container:
```
> sudo docker build .
Sending build context to Docker daemon  982.5kB
Step 1/4 : FROM node:latest
 ---> 2f1ff44a8bb5
Step 2/4 : RUN npm install -g yarn
 ---> Running in 5183549b5eb0
npm ERR! code EEXIST
npm ERR! syscall symlink
npm ERR! path ../lib/node_modules/yarn/bin/yarn.js
npm ERR! dest /usr/local/bin/yarn
npm ERR! errno -17
npm ERR! EEXIST: file already exists, symlink '../lib/node_modules/yarn/bin/yarn.js' -> '/usr/local/bin/yarn'
npm ERR! File exists: /usr/local/bin/yarn
npm ERR! Remove the existing file and try again, or run npm
npm ERR! with --force to overwrite files recklessly.

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2020-02-04T22_12_42_031Z-debug.log
The command '/bin/sh -c npm install -g yarn' returned a non-zero code: 239
```

This causes the build to fail. Removing the yarn installation entirely fixes this issue.