### PR TITLE
Provide 0.3s buffer for silence trimming

### DIFF
--- a/backend/app/audio.py
+++ b/backend/app/audio.py
@@ -13,7 +13,10 @@ class Audio:
         while sound[trim_ms:trim_ms + Audio.chunk_size].dBFS \
                 < Audio.silence_threshold and trim_ms < len(sound):
             trim_ms += Audio.chunk_size
-
+        trim_buffer = 300  # buffer to prevent first sound getting cut
+        trim_ms -= trim_buffer
+        if trim_ms < 0:
+            trim_ms = 0
         return trim_ms
 
     @staticmethod


### PR DESCRIPTION
#### Description
We want to trim the silence from recordings but risk cutting off the first and last syllables, particularly if they are softer sounds. 

This adds a reasonable length buffer for data collection. During post-processing the sounds can be further trimmed if desired.

Fixes #35 

#### Type of PR
- [x] Bugfix

#### Testing
Record samples and ensure the first sound is never cut off. You can also tweak the trim_buffer variable to see that it works eg 1000 will have a 1 second silence at the start and end of each recording.