### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Mimic Recording Studio](#mimic-recording-studio)
   * [Software Quick Start](#software-quick-start)
     + [Windows self-hosted Quick Start](#windows-self-hosted-quick-start)
-    + [Linux/Mac self-hosted Quick Start](#linux-mac-self-hosted-quick-start)
+    + [Linux/Mac self-hosted Quick Start](#linuxmac-self-hosted-quick-start)
       - [Install Dependencies](#install-dependencies)
       - [Build and Run](#build-and-run)
     + [Manual Install, Build and Start](#manual-install--build-and-start)

--- a/start-windows.bat
+++ b/start-windows.bat
@@ -59,9 +59,9 @@ rem set ffmpeg_path="C:\Custom\Path"
 rem Download and install Yarn
 if not exist backend\ffmpeg.exe (
    echo "Installing FFMPEG..."
-   powershell -command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 ; wget https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20181114-1096614-win64-static.zip -outfile ffmpeg.zip"
+   powershell -command "[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12 ; wget https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-20200831-4a11a6f-win64-static.zip -outfile ffmpeg.zip"
    powershell -command "Expand-Archive -Path "ffmpeg.zip" -DestinationPath "ffmpeg"
-   copy ffmpeg\ffmpeg-20181114-1096614-win64-static\bin\ffmpeg.exe backend\ffmpeg.exe
+   copy ffmpeg\ffmpeg-20200831-4a11a6f-win64-static\bin\ffmpeg.exe backend\ffmpeg.exe
 )
 
 rem ======================================================================


### PR DESCRIPTION
#### Description
Fixes a broken anchor link in README, and an old FFMPEG link in the `start-windows.bat` script.

Replaces PR's #29 and #33. In both cases the contributors did not complete a CLA. The changes are not substantive and only fix broken links so have been replicated.

#### Type of PR
- [x] Bugfix

#### CLA
- [x] Yes