### PR TITLE
Added feature to skip a phrase on a recording session.

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -33,31 +33,39 @@ class AudioAPI:
 
     def save_audio(self, audio: bytes, uuid: str, prompt: str):
         user_audio_dir = AudioFS.get_audio_path(uuid)
-        os.makedirs(user_audio_dir, exist_ok=True)
-        wav_file_id = AudioFS.create_file_name(prompt)
-        path = os.path.join(user_audio_dir, wav_file_id)
+        
+        if prompt[0:13] == "___SKIPPED___":
+            res = DB.skipPhrase(uuid)
 
-        try:
-            # save wav file. This step is needed before trimming.
-            AudioFS.save_audio(path, audio)
-            AudioFS.save_meta_data(user_audio_dir, uuid, wav_file_id, prompt)
+            # Save skipped phrase to textfile
+            AudioFS.save_skipped_data(user_audio_dir,uuid,prompt)
+            return response(True)
+        else:
+            os.makedirs(user_audio_dir, exist_ok=True)
+            wav_file_id = AudioFS.create_file_name(prompt)
+            path = os.path.join(user_audio_dir, wav_file_id)
 
-            # trim silence and save
-            trimmed_sound = Audio.trim_silence(path)
-            Audio.save_audio(path, trimmed_sound)
+            try:
+                # save wav file. This step is needed before trimming.
+                AudioFS.save_audio(path, audio)
+                AudioFS.save_meta_data(user_audio_dir, uuid, wav_file_id, prompt)
 
-            res = DB.save_audio(wav_file_id, prompt, 'english', uuid)
-            if res.success:
-                audio_len = Audio.get_audio_len(trimmed_sound)
-                char_len = len(prompt)
-                res = DB.update_user_metrics(uuid, audio_len, char_len)
+                # trim silence and save
+                trimmed_sound = Audio.trim_silence(path)
+                Audio.save_audio(path, trimmed_sound)
+
+                res = DB.save_audio(wav_file_id, prompt, 'english', uuid)
                 if res.success:
-                    return response(True)
-            return response(False)
-        except Exception as e:
-            # TODO: log Exception
-            print(e)
-            return response(False)
+                    audio_len = Audio.get_audio_len(trimmed_sound)
+                    char_len = len(prompt)
+                    res = DB.update_user_metrics(uuid, audio_len, char_len)
+                    if res.success:
+                        return response(True)
+                return response(False)
+            except Exception as e:
+                # TODO: log Exception
+                print(e)
+                return response(False)
 
     def get_audio_len(self, audio: bytes):
         try:

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -125,6 +125,20 @@ class DB:
             response(False)
 
     @staticmethod
+    def skipPhrase(uuid: str) -> response:
+        try:
+            query = UserModel \
+                .update(
+                    prompt_num=UserModel.prompt_num + 1,
+                ) \
+                .where(uuid == uuid)
+            query.execute()
+            return response(True)
+        except Exception as e:
+            print(e)
+            response(False)
+
+    @staticmethod
     def save_audio(audio_id: str, prompt: str,
                    language: str, uuid: str) -> response:
         try:

--- a/backend/app/file_system.py
+++ b/backend/app/file_system.py
@@ -39,8 +39,10 @@ class AudioFS:
     @staticmethod
     def save_audio(path: str, audio: bytes):
         webm_file_name = path + ".webm"
+
         with open(webm_file_name, 'wb+') as f:
             f.write(audio)
+        
         subprocess.call(
             'ffmpeg -i {} -ab 160k -ac 2 -ar 44100 -vn {}.wav -y'.format(
                 webm_file_name, path
@@ -64,6 +66,15 @@ class AudioFS:
         if not same:
             with open(path, 'a') as f:
                 f.write(data)
+
+    @staticmethod
+    def save_skipped_data(user_audio_dir, uuid, prompt):
+        path = os.path.join(user_audio_dir, '%s-skipped.txt' % uuid)
+        data = "{}\n".format(prompt[13:len(prompt)+13])
+
+        with open(path, 'a') as f:
+            f.write(data)
+
 
     @staticmethod
     def get_audio_path(uuid: str) -> str:

--- a/frontend/src/App/Record.js
+++ b/frontend/src/App/Record.js
@@ -81,7 +81,7 @@ class Record extends Component {
         <div className="indicator-container">
           {this.state.shouldRecord
             ? "Read Now [Esc] to cancel"
-            : "[Spacebar] to Start Recording [R] to review [->] for next"}
+            : "[Spacebar] to Start Recording [R] to review [S] to skip [->] for next"}
         </div>
         <div id="controls">
           <a
@@ -237,6 +237,11 @@ class Record extends Component {
       });
     }
 
+    // skip current phrase (S)
+    if (event.keyCode === 83) {
+      this.skipCurrent();
+    }
+
     // play wav
     if (event.keyCode === 82) {
       this.playWav();
@@ -280,6 +285,26 @@ class Record extends Component {
         })
         .catch(err => console.log(err));
     }
+  };
+
+  skipCurrent = () => {
+    // prompt_num in DB um 1 erhöhen und Textfile <uuid>-skipped.txt anlegen und Sätze dort protokollieren
+    postAudio("", "___SKIPPED___" + this.state.prompt, this.uuid)
+    .then(res => res.json())
+    .then(res => {
+      if (res.success) {
+        this.setState({ displayWav: false });
+        this.requestPrompts(this.uuid);
+        this.requestUserDetails(this.uuid);
+        this.setState({
+          blob: undefined,
+          audioLen: 0
+        });
+      } else {
+        alert("There was an error in saving that audio");
+      }
+    })
+    .catch(err => console.log(err));
   };
 
   silenceDetection = stream => {


### PR DESCRIPTION
#### Description
This PR for Mimic-Recording-Studio adds the functionality to skip recording currently shown phrase from the corpus without stopping recording session, editing corpus file and continue training as whished in #51.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Start Mimic-Recording-Studio and record and skip some phrases :-).

#### Documentation
When you are recording using web-ui you can now press "S" to skip recording that shown phrase. That keypress is in addition to existing keypresses (_"R" and "Space"_).

> What's happening when user hits "S"?

When pressing "S" key the web-ui will present the next phrase from the corpus. In the backend the SQLite column "prompt_num" (_table: usermodel_) will be increased on 1. This won't change any value which is used to calculate the average speech rate! No audio file is written in case of "S". If the user wants to clean the corpus file afterwards this can be done by taking a look to the new written text file (_<uuid>-skipped.txt_) in the audio_files/uuid directory. Every skipped phrase will be saved there.
