### PR TITLE
remove unneeded requirements.txt line

### DIFF
--- a/start-windows.bat
+++ b/start-windows.bat
@@ -79,7 +79,6 @@ rem Start web server
 rem ======================================================================
 
 cd frontend
-"%python3_dir%\Scripts\pip.exe" install -r requirements.txt
 cmd /c yarn install
 yarn start
 


### PR DESCRIPTION
#### Description
fixes issue 62 by removing requirements.txt line that is not needed for the front-end 

#### Type of PR
- [X] Bugfix

#### Testing
Running the start-windows.bat script will no longer give an error about missing requirements.txt file

