### PR TITLE
Adding recording tipps on intro in frontend

### DIFF
--- a/frontend/src/App/Intro.js
+++ b/frontend/src/App/Intro.js
@@ -83,6 +83,24 @@ class Intro extends Component {
                 pace, similar to what you might hear from a news anchor.
               </li>
             </ul>
+
+            <hr></hr>
+            <p>
+              In addition please follow these advices for your voice recordings:
+            </p>
+            <ul className="persona-desc">
+              <li><b>Use a good microphone and a quiet recording room setup</b> (no computers fans, air conditioning, ...).</li>
+              <li>Use a text corpus with cleaned numbers/abbreviations and good phoneme coverage.</li>
+              <li>Read neutral, but with a natural speech flow and do not swallow up letters.</li>
+              <li>Adjust tone and pitch with punctuations.</li>
+              <li>Use a constant recording speed.</li>
+              <li>Check your recordings regularly in high volume for background noise.</li>
+              <li>Make breaks regualarly and do not record more than four hours a day.</li>
+              <li>Record error free.</li>
+              </ul>
+
+              <span className="li-title">Happy recording :-)</span>
+
           </div>
           {getName() ? this.renderWelcomeBackMsg() : this.renderInput()}
           <div className="btn_PageIntro">


### PR DESCRIPTION
#### Description
As requested in issue https://github.com/MycroftAI/mimic-recording-studio/issues/59 i've added some recording tipps to the intro in frontend.

<img width="1026" alt="Bildschirmfoto 2021-10-22 um 11 04 35" src="https://user-images.githubusercontent.com/9558265/138427406-da67c46f-5050-4141-b193-eeed53b9a65e.png">

#### Type of PR
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [X] Documentation improvements
- [ ] Test improvements

#### Testing
Check if recording tipps are visible before starting recording session.
