### PR TITLE
Declare file encoding to fix load failure

### DIFF
--- a/backend/app/file_system.py
+++ b/backend/app/file_system.py
@@ -113,7 +113,7 @@ class PromptsFS:
     """API Class for Prompt handling."""
     def __init__(self):
         self.data = []
-        with open(prompts_path, 'r') as f:
+        with open(prompts_path, 'r', encoding='utf8') as f:
             prompts = csv.reader(f, delimiter="\t")
             for p in prompts:
                 self.data.append(p[0])


### PR DESCRIPTION
#### Description
The backend would fail to boot on certain machines without the encoding explicitly set.

Fixes #56 
Also flagged at: https://community.mycroft.ai/t/mimic-recording-studio-installation-problem/12007/2

#### Type of PR
- [x] Bugfix

#### Testing
Ensure backend loads.

#### CLA
- [x] Yes