### PR TITLE
Disable autoGainControl, echoCancellation and noiseSuppression

### DIFF
--- a/frontend/src/App/components/Recorder.js
+++ b/frontend/src/App/components/Recorder.js
@@ -55,7 +55,13 @@ class Recorder extends React.Component {
 			navigator.webkitGetUserMedia);
 
 		if (navigator.getUserMedia && window.MediaRecorder) {
-			const constraints = {audio: true};
+			const constraints = {
+				audio: {
+					echoCancellation: false,
+					autoGainControl: false,
+					noiseSuppression: false,
+				}
+			};
 			this.chunks = [];
 			const { blobOpts, onStop, onError, mediaOpts, onPause, onResume, onStart, gotStream } = this.props;
 


### PR DESCRIPTION
#### Description
I was having issues with recording audio, it seems that a lot of the clips had dips or muffled sounding audio.
I want the clips to retain their clarity and uniformity. Audio processing should much rather take place afterwards rather than "in browser".

After some debugging it turns out that the navigator.getUserMedia created a mediaRecorder with these settings enabled by default.

#### Type of PR
- [x] Bugfix

#### Testing
This was an issue for me on windows and linux, on firefox and chrome, on two different audiocards.
Switching back and forth with the new constraints object was consistent with a fix.

#### Documentation
https://www.w3.org/TR/mediacapture-streams/#def-constraint-echoCancellation

#### CLA
To protect you, the project, and those who choose to use Mycroft technologies in systems they build, we ask all contributors to sign a Contributor License Agreement.

This agreement clarifies that you are granting a license to the Mycroft Project to freely use your work.  Additionally, it establishes that you retain the ownership of your contributed code and intellectual property.  As the owner, you are free to use your code in other work, obtain patents, or do anything else you choose with it.

If you haven't already signed the agreement and been added to our public [Contributors repo](https://github.com/mycroftAI/contributors) then please head to https://mycroft.ai/cla to initiate the signing process.
