### PR TITLE
Bugfix: Add pip upgrade to Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,5 +5,6 @@ COPY requirements.txt /src/
 WORKDIR /src
 RUN apk update
 RUN apk add ffmpeg make automake gcc g++ subversion python3-dev
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 CMD ["sh", "start_prod.sh"]


### PR DESCRIPTION
#### Description
The build was not working, ending in `pip install ... did not complete successfully`, it outputted errors for several packages. Adding a pip upgrade solves the problem with the build.

<details>
<summary>See the error output</summary>

```
 => ERROR [6/6] RUN pip install -r requirements.txt                                                                                                                                     5.0s
------                                                                                                                                                                                       
 > [6/6] RUN pip install -r requirements.txt:                                                                                                                                                
#0 1.140 Collecting flask (from -r requirements.txt (line 1))                                                                                                                                
#0 1.461   Downloading https://files.pythonhosted.org/packages/cd/77/59df23681f4fd19b7cbbb5e92484d46ad587554f5d490f33ef907e456132/Flask-2.0.3-py3-none-any.whl (95kB)                        
#0 1.602 Collecting flask-cors (from -r requirements.txt (line 2))                                                                                                                           
#0 1.914   Downloading https://files.pythonhosted.org/packages/db/84/901e700de86604b1c4ef4b57110d4e947c218b9997adf5d38fa7da493bce/Flask_Cors-3.0.10-py2.py3-none-any.whl                     
#0 1.941 Collecting peewee (from -r requirements.txt (line 3))
#0 2.151   Downloading https://files.pythonhosted.org/packages/a9/50/1dd5ea74c559df4afb8391f8d05f0fec685dbe8effba13bb9072901eb288/peewee-3.16.2.tar.gz (2.9MB)
#0 2.690   Installing build dependencies: started
#0 4.734   Installing build dependencies: finished with status 'done'
#0 4.736   Getting requirements to build wheel: started
#0 4.916   Getting requirements to build wheel: finished with status 'error'
#0 4.916   Complete output from command /usr/local/bin/python /usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpmpjeg42q:
#0 4.916   /tmp/tmp_pw_sqlite3_0khrq23a/test_pw_sqlite3.c:1:21: fatal error: sqlite3.h: No such file or directory
#0 4.916    #include <sqlite3.h>
#0 4.916                        ^
#0 4.916   compilation terminated.
#0 4.916   setup.py:110: UserWarning: Could not find libsqlite3, SQLite extensions will not be built.
#0 4.916     warnings.warn('Could not find libsqlite3, SQLite extensions will not '
#0 4.916   unable to compile sqlite3 C extensions - missing headers?
#0 4.916   Traceback (most recent call last):
#0 4.916     File "/usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 207, in <module>
#0 4.916       main()
#0 4.916     File "/usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 197, in main
#0 4.916       json_out['return_val'] = hook(**hook_input['kwargs'])
#0 4.916     File "/usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 54, in get_requires_for_build_wheel
#0 4.916       return hook(config_settings)
#0 4.916     File "/tmp/pip-build-env-t_1g31lo/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 163, in get_requires_for_build_wheel
#0 4.916       config_settings, requirements=['wheel'])
#0 4.916     File "/tmp/pip-build-env-t_1g31lo/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 143, in _get_build_requires
#0 4.916       self.run_setup()
#0 4.916     File "/tmp/pip-build-env-t_1g31lo/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 158, in run_setup
#0 4.916       exec(compile(code, __file__, 'exec'), locals())
#0 4.916     File "setup.py", line 196, in <module>
#0 4.916       _do_setup(extension_support, sqlite_extension_support)
#0 4.916     File "setup.py", line 150, in _do_setup
#0 4.916       version=__import__('peewee').__version__,
#0 4.916   ModuleNotFoundError: No module named 'peewee'
#0 4.916   
#0 4.916   ----------------------------------------
#0 4.939 Command "/usr/local/bin/python /usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpmpjeg42q" failed with error code 1 in /tmp/pip-install-us1x_ac6/peewee
#0 4.946 You are using pip version 19.0.1, however version 21.3.1 is available.
#0 4.946 You should consider upgrading via the 'pip install --upgrade pip' command.
------
failed to solve: process "/bin/sh -c pip install -r requirements.txt" did not complete successfully: exit code: 1

```

</details>

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Just build the image and test it. It should be working fine on any installation.

#### Documentation
Does not apply
